### PR TITLE
Add custom map color setup

### DIFF
--- a/MapBase/WaferMapControl.xaml.cs
+++ b/MapBase/WaferMapControl.xaml.cs
@@ -31,6 +31,9 @@ namespace MapBase {
         private Dictionary<ushort, Color> _sBinColors = new Dictionary<ushort, Color>();
         private Dictionary<ushort, Color> _hBinColors = new Dictionary<ushort, Color>();
 
+        public Dictionary<ushort, Color> CustomSBinColors { get; } = new Dictionary<ushort, Color>();
+        public Dictionary<ushort, Color> CustomHBinColors { get; } = new Dictionary<ushort, Color>();
+
         private Dictionary<Color, int> _colorDieCnt = new Dictionary<Color, int>();
         //private Dictionary<ushort, int> _sBinDieCnt = new Dictionary<ushort, int>();
         //private Dictionary<ushort, int> _hBinDieCnt = new Dictionary<ushort, int>();
@@ -315,6 +318,13 @@ namespace MapBase {
                 sbFlg = true;
             }
 
+            foreach (var c in CustomHBinColors) {
+                _hBinColors[c.Key] = c.Value;
+            }
+            foreach (var c in CustomSBinColors) {
+                _sBinColors[c.Key] = c.Value;
+            }
+
             int fsbCnt = 0;
             int fhbCnt = 0;
             foreach (var die in _waferData.DieInfoList) {
@@ -414,6 +424,25 @@ namespace MapBase {
             if (_selectedMap is null) return null;
 
             return _selectedMap.GetBitmapSource();
+        }
+
+        public void SetCustomBinColor(ushort bin, Color color, bool isHBin) {
+            if (isHBin) {
+                CustomHBinColors[bin] = color;
+            } else {
+                CustomSBinColors[bin] = color;
+            }
+        }
+
+        public void ClearCustomColors() {
+            CustomSBinColors.Clear();
+            CustomHBinColors.Clear();
+        }
+
+        public void ApplyCustomColors() {
+            if (_waferData != null) {
+                UpdateData();
+            }
         }
 
     }

--- a/SillyMonkey.Core/MessageEvent.cs
+++ b/SillyMonkey.Core/MessageEvent.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DataContainer;
+using System.Windows.Media;
 
 namespace SillyMonkey.Core
 {
@@ -72,6 +73,8 @@ namespace SillyMonkey.Core
 
     public class Event_CorrItemSelected : PubSubEvent<Tuple<string, IEnumerable<SubData>>> {}
     public class Event_SiteCorrItemSelected : PubSubEvent<Tuple<string, SubData>> { }
+
+    public class Event_MapBinColors : PubSubEvent<Tuple<Dictionary<ushort, Color>, Dictionary<ushort, Color>>> { }
 
     public delegate void SubWindowReturnHandler(object obj);
 }

--- a/UI_Chart/Views/WaferMap.xaml.cs
+++ b/UI_Chart/Views/WaferMap.xaml.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Windows.Controls;
+using System.Windows.Media;
 using UI_Chart.ViewModels;
 
 namespace UI_Chart.Views {
@@ -30,6 +31,8 @@ namespace UI_Chart.Views {
             cbBinMode.SelectedItem = MapBinMode.SBin;
             cbViewMode.SelectedItem = MapViewMode.Single;
             cbRtDataMode.SelectedItem = MapRtDataMode.OverWrite;
+
+            _ea.GetEvent<Event_MapBinColors>().Subscribe(ApplyCustomColors);
         }
 
         IRegionManager _regionManager;
@@ -191,6 +194,17 @@ namespace UI_Chart.Views {
 
         private void buttonApplyUserCord_Click(object sender, System.Windows.RoutedEventArgs e) {
             ExecuteCmdApply();
+        }
+
+        void ApplyCustomColors(Tuple<Dictionary<ushort, Color>, Dictionary<ushort, Color>> colors) {
+            waferMap.ClearCustomColors();
+            foreach (var kv in colors.Item1) {
+                waferMap.SetCustomBinColor(kv.Key, kv.Value, false);
+            }
+            foreach (var kv in colors.Item2) {
+                waferMap.SetCustomBinColor(kv.Key, kv.Value, true);
+            }
+            waferMap.ApplyCustomColors();
         }
 
 

--- a/UI_DataList/Views/SetupWindow.xaml
+++ b/UI_DataList/Views/SetupWindow.xaml
@@ -160,6 +160,31 @@
                     </StackPanel>
                 </StackPanel>
             </TabItem>
+
+            <TabItem Header="MapColor">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0" >
+                        <TextBlock Text="Bin Type:" VerticalAlignment="Center" Width="80" Margin="10,0,0,0" />
+                        <ComboBox x:Name="cbBinType" Width="100">
+                            <ComboBoxItem Content="SBin" IsSelected="True" />
+                            <ComboBoxItem Content="HBin" />
+                        </ComboBox>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0" >
+                        <TextBlock Text="Bin No:" VerticalAlignment="Center" Width="80" Margin="10,0,0,0" />
+                        <TextBox x:Name="tbBinNo" Width="100" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0" >
+                        <TextBlock Text="Color:" VerticalAlignment="Center" Width="80" Margin="10,0,0,0" />
+                        <Rectangle x:Name="rectColorPreview" Width="20" Height="20" Fill="Black" Stroke="Black" Margin="0,0,10,0" />
+                        <Button Content="Pick" Width="60" Click="btnPickColor_Click" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0" >
+                        <Button Content="Add/Update" Width="80" Click="btnAddColor_Click" />
+                        <Button Content="Clear" Width="60" Margin="10,0,0,0" Click="btnClearColors_Click" />
+                    </StackPanel>
+                </StackPanel>
+            </TabItem>
         </TabControl>
         <StackPanel Grid.Row="1" VerticalAlignment="Center" Orientation="Vertical" Grid.ColumnSpan="2" Margin="0,11">
             <Button Content="Apply" Width="100" Command="{Binding Apply}"/>

--- a/UI_DataList/Views/SetupWindow.xaml.cs
+++ b/UI_DataList/Views/SetupWindow.xaml.cs
@@ -6,15 +6,25 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows;
 using SillyMonkey.Core.Properties;
+using Prism.Events;
+using Prism.Ioc;
+using System.Windows.Media;
 
 namespace UI_DataList.Views {
     /// <summary>
     /// SetupWindow.xaml 的交互逻辑
     /// </summary>
     public partial class SetupWindow : Window, INotifyPropertyChanged {
+        IEventAggregator _ea;
+        Dictionary<ushort, Color> _customSBinColors = new Dictionary<ushort, Color>();
+        Dictionary<ushort, Color> _customHBinColors = new Dictionary<ushort, Color>();
+        Color _selectedColor = Colors.Black;
         public SetupWindow() {
             DataContext = this;
             InitializeComponent();
+            _ea = ContainerLocator.Container.Resolve<IEventAggregator>();
+            if (cbBinType != null)
+                cbBinType.SelectedIndex = 0;
         }
 
         private string[] _uidTypeList = Enum.GetNames(typeof(UidType));
@@ -188,14 +198,39 @@ namespace UI_DataList.Views {
             set { SA.CorrHistogramEnableDefaultSavePath = value; }
         }
 
+        private void btnPickColor_Click(object sender, RoutedEventArgs e) {
+            var dlg = new System.Windows.Forms.ColorDialog();
+            if (dlg.ShowDialog() == System.Windows.Forms.DialogResult.OK) {
+                _selectedColor = Color.FromArgb(dlg.Color.A, dlg.Color.R, dlg.Color.G, dlg.Color.B);
+                rectColorPreview.Fill = new SolidColorBrush(_selectedColor);
+            }
+        }
+
+        private void btnAddColor_Click(object sender, RoutedEventArgs e) {
+            if (ushort.TryParse(tbBinNo.Text, out ushort bin)) {
+                if (cbBinType.SelectedIndex == 0) {
+                    _customSBinColors[bin] = _selectedColor;
+                } else {
+                    _customHBinColors[bin] = _selectedColor;
+                }
+            }
+        }
+
+        private void btnClearColors_Click(object sender, RoutedEventArgs e) {
+            _customSBinColors.Clear();
+            _customHBinColors.Clear();
+        }
+
         private DelegateCommand _apply;
 
         public DelegateCommand Apply =>
             _apply ?? (_apply = new DelegateCommand(ExecuteApply));
 
         void ExecuteApply() {
-
-
+            _ea.GetEvent<Event_MapBinColors>().Publish(
+                new Tuple<Dictionary<ushort, Color>, Dictionary<ushort, Color>>(
+                    new Dictionary<ushort, Color>(_customSBinColors),
+                    new Dictionary<ushort, Color>(_customHBinColors)));
 
             SA.ApplyAndSave();
             this.Close();


### PR DESCRIPTION
## Summary
- introduce `Event_MapBinColors` for broadcasting custom colors
- allow editing bin colors in `SetupWindow`
- update `WaferMap` view to apply user-defined colors

## Testing
- `dotnet build SillyMonkey.sln -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dde1471b88326bdab64ac6b7ec9a6