### PR TITLE
Fix bin label mapping with custom colors

### DIFF
--- a/SillyMonkey.Core/MessageEvent.cs
+++ b/SillyMonkey.Core/MessageEvent.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using DataContainer;
+using System.Windows.Media;
 
 namespace SillyMonkey.Core
 {
@@ -72,6 +73,8 @@ namespace SillyMonkey.Core
 
     public class Event_CorrItemSelected : PubSubEvent<Tuple<string, IEnumerable<SubData>>> {}
     public class Event_SiteCorrItemSelected : PubSubEvent<Tuple<string, SubData>> { }
+
+    public class Event_MapBinColors : PubSubEvent<Tuple<Dictionary<ushort, Color>, Dictionary<ushort, Color>>> { }
 
     public delegate void SubWindowReturnHandler(object obj);
 }

--- a/UI_Chart/Views/WaferMap.xaml.cs
+++ b/UI_Chart/Views/WaferMap.xaml.cs
@@ -10,6 +10,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Windows.Controls;
+using System.Windows.Media;
 using UI_Chart.ViewModels;
 
 namespace UI_Chart.Views {
@@ -30,6 +31,8 @@ namespace UI_Chart.Views {
             cbBinMode.SelectedItem = MapBinMode.SBin;
             cbViewMode.SelectedItem = MapViewMode.Single;
             cbRtDataMode.SelectedItem = MapRtDataMode.OverWrite;
+
+            _ea.GetEvent<Event_MapBinColors>().Subscribe(ApplyCustomColors);
         }
 
         IRegionManager _regionManager;
@@ -191,6 +194,17 @@ namespace UI_Chart.Views {
 
         private void buttonApplyUserCord_Click(object sender, System.Windows.RoutedEventArgs e) {
             ExecuteCmdApply();
+        }
+
+        void ApplyCustomColors(Tuple<Dictionary<ushort, Color>, Dictionary<ushort, Color>> colors) {
+            waferMap.ClearCustomColors();
+            foreach (var kv in colors.Item1) {
+                waferMap.SetCustomBinColor(kv.Key, kv.Value, false);
+            }
+            foreach (var kv in colors.Item2) {
+                waferMap.SetCustomBinColor(kv.Key, kv.Value, true);
+            }
+            waferMap.ApplyCustomColors();
         }
 
 

--- a/UI_DataList/Views/SetupWindow.xaml
+++ b/UI_DataList/Views/SetupWindow.xaml
@@ -160,6 +160,32 @@
                     </StackPanel>
                 </StackPanel>
             </TabItem>
+
+            <TabItem Header="MapColor">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0" >
+                        <TextBlock Text="Bin Type:" VerticalAlignment="Center" Width="80" Margin="10,0,0,0" />
+                        <ComboBox x:Name="cbBinType" Width="100">
+                            <ComboBoxItem Content="SBin" IsSelected="True" />
+                            <ComboBoxItem Content="HBin" />
+                        </ComboBox>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0" >
+                        <TextBlock Text="Bin No:" VerticalAlignment="Center" Width="80" Margin="10,0,0,0" />
+                        <TextBox x:Name="tbBinNo" Width="100" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0" >
+                        <TextBlock Text="Color:" VerticalAlignment="Center" Width="80" Margin="10,0,0,0" />
+                        <Rectangle x:Name="rectColorPreview" Width="20" Height="20" Fill="Black" Stroke="Black" Margin="0,0,10,0" />
+                        <Button Content="Pick" Width="60" Click="btnPickColor_Click" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0" >
+                        <Button Content="Add/Update" Width="80" Click="btnAddColor_Click" />
+                        <Button Content="Clear" Width="60" Margin="10,0,0,0" Click="btnClearColors_Click" />
+                        <Button Content="Import" Width="70" Margin="10,0,0,0" Click="btnImportColors_Click" />
+                    </StackPanel>
+                </StackPanel>
+            </TabItem>
         </TabControl>
         <StackPanel Grid.Row="1" VerticalAlignment="Center" Orientation="Vertical" Grid.ColumnSpan="2" Margin="0,11">
             <Button Content="Apply" Width="100" Command="{Binding Apply}"/>


### PR DESCRIPTION
## Summary
- track bin IDs alongside colors to uniquely map dies
- update bin count calculation to use bin IDs
- keep bin labels correct when multiple bins share a color
- add import feature to set multiple bin colors at once

## Testing
- `dotnet build SillyMonkey.sln -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dde1471b88326bdab64ac6b7ec9a6