### PR TITLE
Add bulk bin color setting

### DIFF
--- a/UI_DataList/Views/SetupWindow.xaml
+++ b/UI_DataList/Views/SetupWindow.xaml
@@ -183,6 +183,11 @@
                         <Button Content="Add/Update" Width="80" Click="btnAddColor_Click" />
                         <Button Content="Clear" Width="60" Margin="10,0,0,0" Click="btnClearColors_Click" />
                     </StackPanel>
+                    <StackPanel Orientation="Horizontal" Margin="0,3,0,0" >
+                        <TextBlock Text="All Colors:" VerticalAlignment="Center" Width="80" Margin="10,0,0,0" />
+                        <TextBox x:Name="tbAllColors" Width="200" />
+                        <Button Content="ApplyAll" Width="70" Margin="10,0,0,0" Click="btnApplyAllColors_Click" />
+                    </StackPanel>
                 </StackPanel>
             </TabItem>
         </TabControl>

--- a/UI_DataList/Views/SetupWindow.xaml.cs
+++ b/UI_DataList/Views/SetupWindow.xaml.cs
@@ -9,6 +9,7 @@ using SillyMonkey.Core.Properties;
 using Prism.Events;
 using Prism.Ioc;
 using System.Windows.Media;
+using MapBase;
 
 namespace UI_DataList.Views {
     /// <summary>
@@ -219,6 +220,20 @@ namespace UI_DataList.Views {
         private void btnClearColors_Click(object sender, RoutedEventArgs e) {
             _customSBinColors.Clear();
             _customHBinColors.Clear();
+        }
+
+        private void btnApplyAllColors_Click(object sender, RoutedEventArgs e) {
+            var parts = tbAllColors.Text.Split(new char[] { ',', ';', ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+            var list = new List<Color>();
+            foreach (var p in parts) {
+                try {
+                    var c = (Color)ColorConverter.ConvertFromString(p);
+                    list.Add(c);
+                } catch { }
+            }
+            if (list.Count > 0) {
+                BinColor.SetFailBinColors(list.ToArray());
+            }
         }
 
         private DelegateCommand _apply;


### PR DESCRIPTION
## Summary
- add a textbox and button to allow batch setting bin colors
- parse comma separated color names or hex codes and apply them via `BinColor.SetFailBinColors`
- fix missing MapBase using directive

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build SillyMonkey.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f2b2822b88326869ed8800b04091f